### PR TITLE
fix: use context to get configuration

### DIFF
--- a/lib/jekyll_remote_plantuml_plugin/jekyll_remote_plantuml_plugin.rb
+++ b/lib/jekyll_remote_plantuml_plugin/jekyll_remote_plantuml_plugin.rb
@@ -59,7 +59,7 @@ module JekyllRemotePlantUMLPlugin
       tag_options.each { |key, _| tag_options.delete(key) unless TAG_OPTIONS.include?(key) }
 
       # merge with config options
-      configuration_options.merge(tag_options)
+      configuration_options(context).merge(tag_options)
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -78,8 +78,8 @@ module JekyllRemotePlantUMLPlugin
     end
     # rubocop:enable Metrics/MethodLength
 
-    def configuration_options
-      @configuration_options ||= Jekyll.configuration({})["plantuml"].transform_keys(&:to_sym).tap do |conf|
+    def configuration_options(context)
+      @configuration_options ||= context.registers[:site].config["plantuml"].transform_keys(&:to_sym).tap do |conf|
         # delete unsupported options
         conf.each { |key, _| conf.delete(key) unless CONFIG_OPTIONS.include?(key) }
 


### PR DESCRIPTION
- Jekyll.configuration({}) is not correct when mutiple config files are specified
- Do not parse config file, speedup rendering.
- Source: https://github.com/jekyll/jekyll/issues/1578#issuecomment-25109633